### PR TITLE
⚗ Enable SIMD for WASM build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.'cfg(target_arch = "wasm32")']
-rustflags = ["-C", "target-feature=+sign-ext,+bulk-memory,+nontrapping-fptoint"]
+rustflags = ["-C", "target-feature=+sign-ext,+bulk-memory,+nontrapping-fptoint,+simd128"]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -27,7 +27,6 @@ impl Decompressor {
 
     pub fn flush(&mut self) -> Vec<u8> {
         self.inflate.flush().unwrap();
-        let buf = std::mem::replace(self.inflate.get_mut(), vec![]);
-        buf
+        std::mem::replace(self.inflate.get_mut(), vec![])
     }
 }


### PR DESCRIPTION
enabling SIMD should help a tiny bit with speed, although it might not be supported by Deno yet.